### PR TITLE
remove rospy dependency

### DIFF
--- a/ros_monitoring_msgs/CMakeLists.txt
+++ b/ros_monitoring_msgs/CMakeLists.txt
@@ -10,7 +10,6 @@ project(ros_monitoring_msgs)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   message_generation
-  rospy
   std_msgs
 )
 


### PR DESCRIPTION
It's not needed for a pure messages package.
Fix for: http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__ros_monitoring_msgs__ubuntu_xenial_amd64__binary/2/console

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
