### PR TITLE
Update .travis.yml to not allow failures for Melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ros_ci
-script:
-  - .ros_ci/travis.sh
+  install:
+    - git clone https://github.com/ros-industrial/industrial_ci.git .ros_ci
+  script:
+    - .ros_ci/travis.sh


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
